### PR TITLE
Add atomic positions to rho_plot_contour

### DIFF
--- a/RSDFT/RunRSDFT.m
+++ b/RSDFT/RunRSDFT.m
@@ -587,6 +587,16 @@ for i = 1:nev
     fwrite(wfnid, W(:, i), 'double');
 end
 
+% write the atomic structure in wfn.dat
+fwrite(wfnid, N_types, 'uint32' );
+for i=1:N_types
+    xyz = Atoms(i).coord;
+    fwrite(wfnid, length(xyz(:,1)), 'uint32' );
+    for j=1:length(xyz(:,1))
+        fwrite(wfnid, xyz(j, :), 'double');
+    end
+end
+
 fclose(wfnid);
 
 

--- a/RSDFT/main.m
+++ b/RSDFT/main.m
@@ -626,8 +626,17 @@ for i = 1:nev
     fwrite(wfnid, W(:, i), 'double');
 end
 
-fclose(wfnid);
+% write the atomic structure in wfn.dat
+fwrite(wfnid, N_types, 'uint32' );
+for i=1:N_types
+    xyz = Atoms(i).coord;
+    fwrite(wfnid, length(xyz(:,1)), 'uint32' );
+    for j=1:length(xyz(:,1))
+        fwrite(wfnid, xyz(j, :), 'double');
+    end
+end
 
+fclose(wfnid);
 
 fclose(fid); %% Close output file
 

--- a/RSDFT/read_rho.m
+++ b/RSDFT/read_rho.m
@@ -36,9 +36,4 @@ camlight
 lighting gouraud
 
 
-
-
-
-
-
 fclose(wfnid);

--- a/RSDFT/rho_plot_contour.m
+++ b/RSDFT/rho_plot_contour.m
@@ -15,35 +15,40 @@ n2=nx;
 x=[1:n2];
 y=[1:n2];
 z=[1:n2];
-
-
+x=(x-n2*0.5-0.5)*domain.h;
+y=(y-n2*0.5-0.5)*domain.h;
+z=(z-n2*0.5-0.5)*domain.h;
 [rho_length]=fread(wfnid, 1, 'uint32')
-
-
 
 [rho]=fread(wfnid, rho_length, 'double');
 
 V=reshape(rho,n2,n2,n2);
 
-rho_plane(:,:)=(V(:,:,n2/2+1)+V(:,:,n2/2-1))*0.5;
+rho_plane(:,:)=(V(:,:,n2/2+1)+V(:,:,n2/2))*0.5;
 
 rho_plot=rot90(rho_plane);
 
 clf('reset')
 
-
 % FigHandle = figure;
 %  set(FigHandle, 'Position', [100, 100, 500, 500]);
 hold on;
-contour(rho_plot,8,'k')
-hold on;
-plot(42.35,36.5,'o','MarkerFaceColor','k','Markersize',15)
-hold on;
-plot(30.65,36.5,'o','MarkerFaceColor','k','Markersize',15)
+contour(x,y,rho_plot,8,'k')
 
+[w_length]=fread(wfnid, 1, 'uint32' );
+[nev]=fread(wfnid, 1, 'uint32');
+for i = 1:nev
+    [W]=fread(wfnid, w_length, 'double');
+end
 
-
-
-
+[N_types]=fread(wfnid, 1, 'uint32');
+for i=1:N_types
+    [na]=fread(wfnid, 1, 'uint32');
+    for j=1:na
+        xyz=fread(wfnid,3,"double");
+        hold on;
+        plot(xyz(1),xyz(2),'o','MarkerFaceColor','k','Markersize',4)
+    end
+end
 
 fclose(wfnid);

--- a/RSDFT/rho_plot_contour.m
+++ b/RSDFT/rho_plot_contour.m
@@ -46,8 +46,10 @@ for i=1:N_types
     [na]=fread(wfnid, 1, 'uint32');
     for j=1:na
         xyz=fread(wfnid,3,"double");
-        hold on;
-        plot(xyz(1),xyz(2),'o','MarkerFaceColor','k','Markersize',4)
+        if (xyz(3) < domain.h * 0.5 && xyz(3) > -domain.h * 0.5)
+            hold on;
+            plot(xyz(1),xyz(2),'o','MarkerFaceColor','k','Markersize',4)
+        end
     end
 end
 


### PR DESCRIPTION
Now, rho_plot_contour can display the atomic positions, with the real-space length as the x and y axes.