### PR TITLE
Vectorize hot spline evaluations in ionic potential loops

### DIFF
--- a/RSDFT/IonicPotentialFindingFiles/pseudoDiag.m
+++ b/RSDFT/IonicPotentialFindingFiles/pseudoDiag.m
@@ -100,6 +100,9 @@ for at_typ=1:N_types
     [z_chg,c_chg,d_chg]=fspline(x_charg, y_charg);
     [z_p_s,c_p_s,d_p_s]=fspline(x_pot_s, y_pot_s);
     [z_vht,c_vht,d_vht]=fspline(x_vhart, y_vhart);
+    pp_chg = fsplinepp(z_chg,c_chg,d_chg,x_charg);
+    pp_p_s = fsplinepp(z_p_s,c_p_s,d_p_s,x_pot_s);
+    pp_vht = fsplinepp(z_vht,c_vht,d_vht,x_vhart);
     
 %-- Scan all points for each atom (not optimal but OK)--copied from
 %-- ppot.m with a small change of formula to find potential
@@ -130,24 +133,15 @@ for at_typ=1:N_types
                 
 
                 if (OPTIMIZATIONLEVEL~=0)
-                	% a c version of the inner most for loop
+                    % a c version of the inner most for loop
                     [ppot,rrho,hpot00]=PsuedoDiagLoops(z_p_s,c_p_s,d_p_s,z_chg,c_chg,d_chg,z_vht,c_vht,d_vht,x_pot_s,x_charg,x_vhart,r1,j_p_s,j_ch,j_vht,nx);
                 else
-                	for i=1:2:nx
-%%----------------- Evaluating the splines
-                    	% loop has been unrolled once, can be done because nx
-                    	% is always even
-                    	iPlusOne=i+1;
-                    	[ppot(i,1) j_p_s]   = fsplevalIO(z_p_s,c_p_s,d_p_s,x_pot_s,r1(i),j_p_s);
-                    	[rrho(i,1) j_ch]    = fsplevalIO(z_chg,c_chg,d_chg,x_charg,r1(i),j_ch);
-                    	[hpot00(i,1) j_vht] = fsplevalIO(z_vht,c_vht,d_vht,x_vhart,r1(i),j_vht);
-                    
-                    	[ppot(iPlusOne,1) j_p_s]   = fsplevalIO(z_p_s,c_p_s,d_p_s,x_pot_s,r1(iPlusOne),j_p_s);
-                    	[rrho(iPlusOne,1) j_ch]    = fsplevalIO(z_chg,c_chg,d_chg,x_charg,r1(iPlusOne),j_ch);
-                    	[hpot00(iPlusOne,1) j_vht] = fsplevalIO(z_vht,c_vht,d_vht,x_vhart,r1(iPlusOne),j_vht);                  
-%%----------------- done atom-specific calculations - now compute
-%%----------------- potentials, charge.    
-                	end  %% end x
+                    ppot = fsppval(pp_p_s,r1);
+                    rrho = fsppval(pp_chg,r1);
+                    hpot00 = fsppval(pp_vht,r1);
+                    ppot = ppot(:);
+                    rrho = rrho(:);
+                    hpot00 = hpot00(:);
                 end
                 
                 if (enableMexFilesTest==1)
@@ -176,4 +170,3 @@ end                  %% end atom_typ
 %%---- Check charge
 Rsum0=sum(rho0);
 rho0=Z_sum*rho0/Rsum0;
-

--- a/RSDFT/IonicPotentialFindingFiles/pseudoNL.m
+++ b/RSDFT/IonicPotentialFindingFiles/pseudoNL.m
@@ -107,6 +107,8 @@ for at_typ=1:N_types
 
   [zWav, cWav, dWav] = fspline(xi_wfn_P,wfn_P);
   [zPotPS, cPotPS, dPotPS] = fspline(xi_potPS,potPS);
+  ppWav = fsplinepp(zWav,cWav,dWav,xi_wfn_P);
+  ppPotPS = fsplinepp(zPotPS,cPotPS,dPotPS,xi_potPS);
 %%--------------------  End generating the coefficients for splines
 
   for i = 1:length(elem.data)
@@ -153,12 +155,17 @@ for at_typ=1:N_types
     span=round(Rzero/h);   %%%-
 
     indx=0;
+    max_points = (2*span + 1)^3;
+    nn = zeros(1,max_points);
+    xx = zeros(1,max_points);
+    yy = zeros(1,max_points);
+    zz = zeros(1,max_points);
+    dd = zeros(1,max_points);
 
     for k=k0-span:k0+span
       zzz = (k-1)*h - rad - zza;
       for j=j0-span:j0+span
         yyy = (j-1)*h - rad - yya;
-        j_p_ps = 1; j_wfn = 1;
         for i=i0-span:i0+span
           xxx = (i-1)*h - rad - xxa;
 %-------------------- calculate distance from (xxx,yyy,zzz) to atom
@@ -175,12 +182,18 @@ for at_typ=1:N_types
             yy(indx)=yyy;
             zz(indx)=zzz;
             dd(indx)=dd1;
-            [ vspp(indx)  j_p_ps ] = fsplevalIO(zPotPS,cPotPS,dPotPS,xi_potPS,dd1, j_p_ps);
-            [ wavpp(indx) j_wfn  ] = fsplevalIO(zWav,cWav,dWav,xi_wfn_P,dd1, j_wfn);
           end % end of core size if statement
         end % end of for loop concerning xxx
       end % end of for loop concerning yyy
     end % end of for loop concerning zzz
+    active_points = 1:indx;
+    nn = nn(active_points);
+    xx = xx(active_points);
+    yy = yy(active_points);
+    zz = zz(active_points);
+    dd = dd(active_points);
+    vspp = fsppval(ppPotPS,dd);
+    wavpp = fsppval(ppWav,dd);
 %
     %%%%%%% DEBUGGING INFORMATION %%%%%%%
 %   disp('Z xint')

--- a/RSDFT/SPLINES/fsplinepp.m
+++ b/RSDFT/SPLINES/fsplinepp.m
@@ -1,0 +1,19 @@
+function pp = fsplinepp(z,c,d,xi)
+%% pp = fsplinepp(z,c,d,xi)
+%% converts fspline coefficients to a MATLAB piecewise polynomial.
+
+xi = xi(:)';
+z = z(:)';
+c = c(:)';
+d = d(:)';
+
+h = xi(2:end) - xi(1:end-1);
+
+coefs = [ ...
+    ((z(2:end) - z(1:end-1)) ./ h).' ...
+    (3*z(1:end-1)).' ...
+    (d(1:end) - c(1:end) - 3*h.*z(1:end-1)).' ...
+    (z(1:end-1).*h.^2 + c(1:end).*h).' ...
+];
+
+pp = mkpp(xi, coefs);

--- a/RSDFT/SPLINES/fsppval.m
+++ b/RSDFT/SPLINES/fsppval.m
@@ -1,0 +1,12 @@
+function y = fsppval(pp,x)
+%% y = fsppval(pp,x)
+%% evaluates a clamped fspline piecewise polynomial at all points in x.
+
+x_size = size(x);
+xq = x(:)';
+breaks = pp.breaks;
+
+xq = min(max(xq, breaks(1)), breaks(end));
+
+y = ppval(pp, xq);
+y = reshape(y, x_size);


### PR DESCRIPTION
**Description**
This PR improves the MATLAB fallback performance for ionic potential setup by removing repeated scalar `fsplevalIO` calls from hot inner loops.

Changes:
- Add `fsplinepp` to convert existing `fspline` coefficients into MATLAB piecewise-polynomial form.
- Add `fsppval` to clamp query points and evaluate spline values with vectorized `ppval`.
- Update `pseudoDiag` so the non-MEX path evaluates full `r1` rows at once.
- Update `pseudoNL` so it collects active grid-point distances first, then evaluates the potential and wavefunction splines in batches.
- Preallocate per-atom work arrays in `pseudoNL` to avoid dynamic growth in the inner loop.

**Notes**
- The existing `fsplevalIO` scalar evaluator is left in place for compatibility.
- No simulation outputs or generated run artifacts are included.