### PR TITLE
[performance improvement] Vectorize Rayleigh–Ritz projection fallback

### DIFF
--- a/RSDFT/DiagonalizationFiles/chefsi1.m
+++ b/RSDFT/DiagonalizationFiles/chefsi1.m
@@ -47,12 +47,7 @@ Vin = H*W;
 if (OPTIMIZATIONLEVEL~=0)
 	G=Rayleighritz(Vin,W,n2);
 else
-    for j=1:n2
-        for i=1:j
-            G(i,j) = Vin(:,i)'*W(:,j);
-            G(j,i) = G(i,j);
-        end
-    end
+    G = rayleighRitzProduct(Vin,W);
     if (enableMexFilesTest==1)
         G2=Rayleighritz(Vin,W,n2);
         if (any(abs(G-G2)>0.000001))

--- a/RSDFT/DiagonalizationFiles/chsubsp.m
+++ b/RSDFT/DiagonalizationFiles/chsubsp.m
@@ -47,14 +47,7 @@ for it = 1:Max_out_iter
     if (OPTIMIZATIONLEVEL~=0)
         G=Rayleighritz(Vin,W,n2);
     else
-        %preallocating G
-        G=zeros(n2,n2);
-        for j=1:n2
-            for i=1:j
-                G(i,j) = Vin(:,i)'*W(:,j);
-                G(j,i) = G(i,j);
-            end
-        end
+        G = rayleighRitzProduct(Vin,W);
         if (enableMexFilesTest==1)
             G2=Rayleighritz(Vin,W,n2);
             if (any(abs(G-G2)>0.000001))

--- a/RSDFT/DiagonalizationFiles/first_filt.m
+++ b/RSDFT/DiagonalizationFiles/first_filt.m
@@ -52,14 +52,7 @@ for it = 1 : max_iter
     if (OPTIMIZATIONLEVEL~=0)
         G=Rayleighritz(Vin,W,n2);
     else
-        % reuse G and overwrite it
-        G=zeros(n2,n2);
-        for j=1:n2
-            for i=1:j
-                G(i,j) = Vin(:,i)'*W(:,j);
-                G(j,i) = G(i,j);
-            end
-        end
+        G = rayleighRitzProduct(Vin,W);
     end
 
     [Q, D] = eig(G);

--- a/RSDFT/DiagonalizationFiles/lanczos.m
+++ b/RSDFT/DiagonalizationFiles/lanczos.m
@@ -197,12 +197,7 @@ else
     if (OPTIMIZATIONLEVEL~=0)
         G=Rayleighritz(Vin,W,mev);
     else
-        for j=1:mev
-            for i=1:j
-                G(i,j) = Vin(:,i)'*W(:,j);
-                G(j,i) = G(i,j);
-            end
-        end
+        G = rayleighRitzProduct(Vin,W);
         if (enableMexFilesTest==1)
             G2=Rayleighritz(Vin,W,mev);
             if (any(abs(G-G2)>0.000001))

--- a/RSDFT/DiagonalizationFiles/lanczosForChsubsp.m
+++ b/RSDFT/DiagonalizationFiles/lanczosForChsubsp.m
@@ -172,12 +172,7 @@ else
     if (OPTIMIZATIONLEVEL~=0)
         G=Rayleighritz(Vin,W,mev);
     else
-        for j=1:mev
-            for i=1:j
-                G(i,j) = Vin(:,i)'*W(:,j);
-                G(j,i) = G(i,j);
-            end
-        end
+        G = rayleighRitzProduct(Vin,W);
         if (enableMexFilesTest==1)
             G2=Rayleighritz(Vin,W,mev);
             if (any(abs(G-G2)>0.000001))

--- a/RSDFT/DiagonalizationFiles/rayleighRitzProduct.m
+++ b/RSDFT/DiagonalizationFiles/rayleighRitzProduct.m
@@ -1,0 +1,6 @@
+function G = rayleighRitzProduct(Vin,W)
+%% G = rayleighRitzProduct(Vin,W)
+%% computes the same Rayleigh-Ritz projection as the old MATLAB loops.
+
+G = Vin' * W;
+G = triu(G) + triu(G,1)';


### PR DESCRIPTION
## Description

This PR improves the MATLAB fallback path for Rayleigh–Ritz projection construction.

Previously, several diagonalization routines built `G` with nested MATLAB loops:

```matlab
G(i,j) = Vin(:,i)' * W(:,j);
G(j,i) = G(i,j);
```

This PR adds `rayleighRitzProduct`, which computes:

```matlab
G = Vin' * W;
G = triu(G) + triu(G,1)';
```

That keeps the same upper-triangle-then-mirror behavior while using MATLAB’s optimized matrix multiplication.

Updated call sites:
- `chefsi1.m`
- `chsubsp.m`
- `first_filt.m`
- `lanczos.m`
- `lanczosForChsubsp.m`

## Validation

- Confirmed all replaced loops used the same `for j=1:m`, `for i=1:j` indexing pattern.
- Confirmed `m` matches the relevant projected basis column count: `n2` or `mev`.
- Confirmed the replacement matches the existing `Rayleighritz.c` 0-based loop logic.